### PR TITLE
feat: add global cookie banner fixture to auto-dismiss on page load

### DIFF
--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -1,0 +1,43 @@
+import { test as base, Page } from '@playwright/test';
+import { SELECTORS, TIMEOUTS } from './constants';
+
+/**
+ * Dismisses the cookie banner if it appears on the page.
+ * Silently continues if banner is not found.
+ */
+async function dismissCookieBanner(page: Page) {
+  const cookieBanner = page.locator(SELECTORS.COOKIE_BANNER);
+  try {
+    // Check if banner is visible with a short timeout
+    if (await cookieBanner.isVisible({ timeout: TIMEOUTS.SHORT })) {
+      await cookieBanner.click();
+      // Wait for animation to complete
+      await page.waitForTimeout(500);
+    }
+  } catch (e) {
+    // Banner not found or not clickable - that's fine, continue
+  }
+}
+
+/**
+ * Custom test fixture that automatically dismisses cookie banners on page load.
+ * Usage: Import { test, expect } from '../helpers/fixtures' instead of '@playwright/test'
+ */
+export const test = base.extend({
+  page: async ({ page }, use) => {
+    // This runs BEFORE each test
+    // Set up a listener that dismisses cookies whenever a page loads
+    page.on('load', async () => {
+      await dismissCookieBanner(page);
+    });
+    
+    // Give the page to the test
+    await use(page);
+    
+    // This runs AFTER each test (cleanup if needed)
+    // Nothing to clean up for cookie banner
+  },
+});
+
+// Re-export expect so tests can import both from one place
+export { expect } from '@playwright/test';

--- a/tests/specs/athlete_bull.spec.ts
+++ b/tests/specs/athlete_bull.spec.ts
@@ -1,7 +1,7 @@
-import { test, expect } from '@playwright/test';
-import { normalizeName } from '../helpers/utils';
+import { test, expect } from '../helpers/fixtures'
 import { getFirstAthleteCard, openFirstAthleteProfile } from '../helpers/athletes';
 import { SELECTORS } from '../helpers/constants';
+import { normalizeName } from '../helpers/utils';
 
 test('selecting a bull displays their page', async ({ page }) => {
     const firstBull = await getFirstAthleteCard(page, 'Bulls');

--- a/tests/specs/athlete_rider.spec.ts
+++ b/tests/specs/athlete_rider.spec.ts
@@ -1,7 +1,8 @@
-import { test, expect, Page, Locator } from '@playwright/test';
-import { SELECTORS, TIMEOUTS } from '../helpers/constants';
-import { normalizeName } from '../helpers/utils';
+import { test, expect } from '../helpers/fixtures'
+import { Page, Locator } from '@playwright/test'
 import { getFirstAthleteCard, openFirstAthleteProfile } from '../helpers/athletes';
+import { SELECTORS, TIMEOUTS } from '../helpers/constants'
+import { normalizeName } from '../helpers/utils';
 
 async function clickSeasonTab(page: Page) {
   const seasonTab = page.locator('#season-tab')

--- a/tests/specs/bull_standings.spec.ts
+++ b/tests/specs/bull_standings.spec.ts
@@ -1,4 +1,5 @@
-import { test, expect, Page, Locator } from '@playwright/test';
+import { test, expect } from '../helpers/fixtures'
+import { Page, Locator } from '@playwright/test'
 import { TIMEOUTS, SELECTORS } from '../helpers/constants';
 import { normalizeName } from '../helpers/utils';
 

--- a/tests/specs/event_schedule.spec.ts
+++ b/tests/specs/event_schedule.spec.ts
@@ -1,4 +1,5 @@
-import { test, expect, Page, Locator } from '@playwright/test'
+import { test, expect } from '../helpers/fixtures'
+import { Page, Locator } from '@playwright/test'
 import { openNavLink } from '../helpers/utils'
 
 test.setTimeout(60000)
@@ -20,14 +21,6 @@ test.beforeEach(async ({ page }) => {
     'events',
     'PBR | Events'
   )
-
-  // Dismiss cookie banner if present
-  const cookieBanner = page.locator('#onetrust-accept-btn-handler')
-  const cookieBannerVisible = await cookieBanner.isVisible({ timeout: 2000 }).catch(() => false)
-  if (cookieBannerVisible) {
-    await cookieBanner.click({ timeout: 5000 }).catch(() => {})
-    await page.waitForTimeout(500)
-  }
 
   await page.locator('.eventScheduleItem').first().waitFor({ state: 'visible' })
 })

--- a/tests/specs/meet_the_team.spec.ts
+++ b/tests/specs/meet_the_team.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from '../helpers/fixtures'
 import { clickAndWaitForPopup, openNavLink } from '../helpers/utils'
 
 test.beforeEach(async ({ page }) => {
@@ -14,10 +14,7 @@ test.beforeEach(async ({ page }) => {
 test('user can view official team site', async ({ page }) => {
     const officialSiteLink = await page.getByRole('link', { name: 'Visit Official Site' })
 
-    const popup = await clickAndWaitForPopup(
-        page,
-        officialSiteLink.click()
-    )
+    const popup = await clickAndWaitForPopup(page, officialSiteLink.click())
 
     await expect(popup).toHaveURL(/arizonaridgeriders\.com/)
 })

--- a/tests/specs/mvp_race.spec.ts
+++ b/tests/specs/mvp_race.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from '../helpers/fixtures'
 import { TIMEOUTS, URLS } from '../helpers/constants';
 import { normalizeName } from '../helpers/utils'
 
@@ -17,25 +17,25 @@ test('when a user selects a year, the standings display', async({ page }) => {
     await yearButton.click()
     
     const yearSlideActive = yearButton.locator('.seasonBlock.active')
-    await expect(yearSlideActive).toBeVisible()
+    await expect(yearSlideActive).toBeVisible({ timeout: TIMEOUTS.MEDIUM })
     
     const activePane = page.locator('#regular-season-pane.tab-pane.active')
     const table = activePane.locator('#standingsTable')
-    await expect(table).toBeVisible()
+    await expect(table).toBeVisible({ timeout: TIMEOUTS.MEDIUM })
 })
 
 test('when a user selects the championship MVP tab, the standings display', async({ page }) => {
     await page.locator('#champion-tab').click()
     const activePane = page.locator('#championship-pane.tab-pane.active')
-    await expect(activePane).toBeVisible()
+    await expect(activePane).toBeVisible({ timeout: TIMEOUTS.MEDIUM })
 
     const topCard = activePane.locator('.standingsTop3').first()
     const topCardName = (await topCard.locator('h3').nth(1).innerText()).trim()
 
-    const table = activePane.locator('#standingsTable');
+    const table = activePane.locator('#standingsTable')
     const rowOneRider = table.locator('tbody tr').first().locator('td').nth(2).locator('a')
-    await expect(rowOneRider).toBeVisible();
-    const rowOneRiderText = (await rowOneRider.innerText()).trim();
+    await expect(rowOneRider).toBeVisible({ timeout: TIMEOUTS.MEDIUM })
+    const rowOneRiderText = (await rowOneRider.innerText()).trim()
 
-    expect(rowOneRiderText).toBe(normalizeName(topCardName));
+    expect(rowOneRiderText).toBe(normalizeName(topCardName))
 })

--- a/tests/specs/results.spec.ts
+++ b/tests/specs/results.spec.ts
@@ -1,5 +1,6 @@
-import { test, expect, Page } from '@playwright/test';
-import { TIMEOUTS, URLS } from '../helpers/constants';
+import { test, expect } from '../helpers/fixtures'
+import { Page, Locator } from '@playwright/test'
+import { TIMEOUTS, URLS } from '../helpers/constants'
 
 /**
  * Opens a results page from the Results dropdown
@@ -18,7 +19,12 @@ async function openResultsPage(
   }
 ) {
   const resultsDropdown = page.locator('.dropdown-menu.dropdown-menu-end.show')
-  await resultsDropdown.getByRole('link', { name: dropDownValue }).click()
+  await resultsDropdown.waitFor({ state: 'visible', timeout: TIMEOUTS.MEDIUM })
+  await page.waitForTimeout(500)
+
+  const item = resultsDropdown.locator(`a:has-text("${dropDownValue}")`)
+  await expect(item).toBeVisible({ timeout: TIMEOUTS.MEDIUM })
+  await item.click()
 
   // If we need to click a card (All Around scenario)
   if (options?.cardTitle) {
@@ -50,8 +56,19 @@ async function verifyStandingResultsDisplay(page: Page) {
 }
 
 test.beforeEach(async ({ page }) => {
-    await page.goto(URLS.HOME)
-    await page.getByRole('button', { name: 'Results' }).click()
+    await page.goto(URLS.HOME, {
+      waitUntil: 'domcontentloaded',
+      timeout: TIMEOUTS.NAVIGATION
+    })
+
+    const resultsButton = page.getByRole('button', { name: 'Results' })
+    await expect(resultsButton).toBeVisible({ timeout: TIMEOUTS.MEDIUM })
+    await resultsButton.click()
+
+    await page.locator('.dropdown-menu.dropdown-menu-end.show').waitFor({ 
+      state: 'visible', 
+      timeout: TIMEOUTS.MEDIUM 
+    })
 })
 
 test('a user can view standings', async ({ page }) => {

--- a/tests/specs/rookie_of_the_year.spec.ts
+++ b/tests/specs/rookie_of_the_year.spec.ts
@@ -1,4 +1,5 @@
-import { test, expect, Page } from '@playwright/test';
+import { test, expect } from '../helpers/fixtures'
+import { Page, Locator } from '@playwright/test'
 import { URLS } from '../helpers/constants';
 import { normalizeName } from '../helpers/utils';
 


### PR DESCRIPTION
Created custom Playwright fixture that automatically dismisses cookie banners whenever a page loads. Updated all spec files to use the new fixture and removed manual cookie dismissal code. Fixed various timing issues in WebKit tests.

Resolves #50